### PR TITLE
Specify the namespace in the rolebinding name

### DIFF
--- a/openshift/multi-project-templates/user-rolebinding.yml
+++ b/openshift/multi-project-templates/user-rolebinding.yml
@@ -27,7 +27,7 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    name: ${CLUSTER_ROLE}-${USER}
+    name: ${CLUSTER_ROLE}-${USER}-${NAMESPACE}
     namespace: ${NAMESPACE}
   roleRef:
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This commit if applied will change the name of the role binding to incorporate the name of the namespace to avoid conflicts.

This will allow users to use this template and create several namespaces without conflicts in rolebinding names.