### PR TITLE
update php version

### DIFF
--- a/openshift/multi-project-templates/cakephp-build.yml
+++ b/openshift/multi-project-templates/cakephp-build.yml
@@ -52,7 +52,7 @@ parameters:
   displayName: PHP Version
   description: Version of PHP image to be used (7.1 or latest).
   required: true
-  value: '7.1'
+  value: '7.3'
 - name: SOURCE_REPOSITORY_URL
   displayName: Git Repository URL
   description: The URL of the repository with your application source code.

--- a/openshift/templates/cakephp-mysql-persistent.yml
+++ b/openshift/templates/cakephp-mysql-persistent.yml
@@ -38,7 +38,7 @@ parameters:
   displayName: PHP Version
   description: Version of PHP image to be used (7.1 or latest).
   required: true
-  value: '7.1'
+  value: '7.3'
 - name: MEMORY_LIMIT
   displayName: Memory Limit
   description: Maximum amount of memory the CakePHP container can use.

--- a/openshift/templates/cakephp-mysql.yml
+++ b/openshift/templates/cakephp-mysql.yml
@@ -41,7 +41,7 @@ parameters:
   displayName: PHP Version
   description: Version of PHP image to be used (7.1 or latest).
   required: true
-  value: '7.1'
+  value: '7.3'
 - name: MEMORY_LIMIT
   displayName: Memory Limit
   description: Maximum amount of memory the CakePHP container can use.

--- a/openshift/templates/cakephp.yml
+++ b/openshift/templates/cakephp.yml
@@ -40,7 +40,7 @@ parameters:
   displayName: PHP Version
   description: Version of PHP image to be used (7.1 or latest).
   required: true
-  value: '7.1'
+  value: '7.3'
 - name: MEMORY_LIMIT
   displayName: Memory Limit
   description: Maximum amount of memory the container can use.


### PR DESCRIPTION
The 7.1 version is no longer available in OpenShift 4.5. This changes things from 7.1 > 7.3.

I do not know if 7.3 is available in earlier versions of OpenShift, so this hasn't been tested there.